### PR TITLE
feature/IM-224 | Approval Test 용 YamlWriter 추가

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.16.1")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.1")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1")
 
     // Use JUnit Jupiter for testing.
     testImplementation(libs.junit.jupiter)
@@ -36,7 +37,6 @@ dependencies {
 
 java {
     toolchain {
-//        languageVersion.set(JavaLanguageVersion.of(8))
         languageVersion.set(JavaLanguageVersion.of(17))
     }
     withJavadocJar()

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -19,12 +19,14 @@ publishing {
     }
 }
 
+val jacksonVersion by extra { "2.16.1" }
+
 dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation("com.fasterxml.jackson.core:jackson-core:2.16.1")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.1")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1")
+    implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
 
     // Use JUnit Jupiter for testing.
     testImplementation(libs.junit.jupiter)

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "com.ktown4u"
             artifactId = "utils"
-            version = "1.1.0"
+            version = "1.2.0"
 
             from(components["java"])
         }

--- a/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
@@ -34,6 +34,10 @@ public enum YamlWriter {
         final SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.serializeAllExcept(fieldNamesToExclude);
         final FilterProvider filterProvider = new SimpleFilterProvider().addFilter("PropertyFilter", filter);
         final ObjectWriter writer = mapper.writer(filterProvider);
+        return writeValueAsString(writer, object);
+    }
+
+    private static String writeValueAsString(final ObjectWriter writer, final Object object) {
         try {
             return writer.writeValueAsString(object);
         } catch (final JsonProcessingException e) {

--- a/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
@@ -32,8 +33,9 @@ public enum YamlWriter {
     public static String writeWithExclusions(final Object object, final String... fieldNamesToExclude) {
         final SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.serializeAllExcept(fieldNamesToExclude);
         final FilterProvider filterProvider = new SimpleFilterProvider().addFilter("PropertyFilter", filter);
+        final ObjectWriter writer = mapper.writer(filterProvider);
         try {
-            return mapper.writer(filterProvider).writeValueAsString(object);
+            return writer.writeValueAsString(object);
         } catch (final JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
@@ -23,6 +23,7 @@ public enum YamlWriter {
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE); // Disable auto-detection for all methods
         mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY); // Enable visibility for fields
+        // @JsonFilter가 붙은 클래스만 필터링할 수 있는 것 같음. 모든 클래스에 쉽게 필터링을 적용하기 위해 Object에 mix-in 적용.
         mapper.addMixIn(Object.class, PropertyFilterMixIn.class);
     }
 

--- a/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
@@ -1,9 +1,30 @@
 package com.ktown4u.utils;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 public enum YamlWriter {
     ;
+    private static final ObjectMapper mapper;
+
+    static {
+        mapper = new ObjectMapper(new YAMLFactory());
+        mapper.findAndRegisterModules();
+        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE); // Disable auto-detection for all methods
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY); // Enable visibility for fields
+    }
 
     public static String write(final Object object) {
-        throw new UnsupportedOperationException("Not implemented");
+        try {
+            return mapper.writeValueAsString(object);
+        } catch (final JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
@@ -27,4 +27,8 @@ public enum YamlWriter {
             throw new RuntimeException(e);
         }
     }
+
+    public static String writeWithExclusions(final Object object, final String... fieldNamesToExclude) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 }

--- a/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlWriter.java
@@ -1,0 +1,9 @@
+package com.ktown4u.utils;
+
+public enum YamlWriter {
+    ;
+
+    public static String write(final Object object) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/lib/src/test/java/com/ktown4u/utils/OrderBuilder.java
+++ b/lib/src/test/java/com/ktown4u/utils/OrderBuilder.java
@@ -1,0 +1,97 @@
+package com.ktown4u.utils;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+class OrderBuilder {
+    private Long id;
+    private List<OrderLineItem> lineItems = new ArrayList<>();
+
+    public OrderBuilder id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public OrderBuilder orderLineItems(OrderLineItemBuilder... lineItemBuilders) {
+        for (OrderLineItemBuilder lineItemBuilder : lineItemBuilders) {
+            this.lineItems.add(lineItemBuilder.build());
+        }
+        return this;
+    }
+
+    public Order build() {
+        Order order = new Order();
+        order.setId(id);
+        order.setLineItems(lineItems);
+        return order;
+    }
+
+    public static OrderBuilder anOrder() {
+        return new OrderBuilder();
+    }
+}
+
+class OrderLineItemBuilder {
+    private Long id;
+    private Long quantity;
+    private Product product;
+
+    public OrderLineItemBuilder id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public OrderLineItemBuilder quantity(Long quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    public OrderLineItemBuilder product(ProductBuilder productBuilder) {
+        this.product = productBuilder.build();
+        return this;
+    }
+
+    public OrderLineItem build() {
+        OrderLineItem lineItem = new OrderLineItem();
+        lineItem.setId(id);
+        lineItem.setQuantity(quantity);
+        lineItem.setProduct(product);
+        return lineItem;
+    }
+
+    public static OrderLineItemBuilder anOrderLineItem() {
+        return new OrderLineItemBuilder();
+    }
+}
+
+class ProductBuilder {
+    private Long id;
+    private String name;
+    private String description;
+    private BigDecimal price;
+
+
+    public ProductBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ProductBuilder price(String price) {
+        this.price = new BigDecimal(price);
+        return this;
+    }
+
+    public Product build() {
+        Product product = new Product();
+        product.setId(id);
+        product.setName(name);
+        product.setDescription(description);
+        product.setPrice(price);
+        return product;
+    }
+
+    public static ProductBuilder aProduct() {
+        return new ProductBuilder();
+    }
+}

--- a/lib/src/test/java/com/ktown4u/utils/OrderBuilder.java
+++ b/lib/src/test/java/com/ktown4u/utils/OrderBuilder.java
@@ -82,6 +82,11 @@ class ProductBuilder {
         return this;
     }
 
+    public ProductBuilder description(final String description) {
+        this.description = description;
+        return this;
+    }
+
     public Product build() {
         Product product = new Product();
         product.setId(id);

--- a/lib/src/test/java/com/ktown4u/utils/PrettyJsonPrinterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/PrettyJsonPrinterTest.java
@@ -3,10 +3,6 @@ package com.ktown4u.utils;
 import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-
 import static com.ktown4u.utils.OrderBuilder.anOrder;
 import static com.ktown4u.utils.OrderLineItemBuilder.anOrderLineItem;
 import static com.ktown4u.utils.PrettyJsonPrinter.outLinesIncluding;
@@ -40,97 +36,5 @@ class PrettyJsonPrinterTest {
                 .filter(outLinesIncluding("description"))
                 .collect(joining("\n"))
         );
-    }
-}
-
-class OrderBuilder {
-    private Long id;
-    private List<OrderLineItem> lineItems = new ArrayList<>();
-
-    public OrderBuilder id(Long id) {
-        this.id = id;
-        return this;
-    }
-
-    public OrderBuilder orderLineItems(OrderLineItemBuilder... lineItemBuilders) {
-        for (OrderLineItemBuilder lineItemBuilder : lineItemBuilders) {
-            this.lineItems.add(lineItemBuilder.build());
-        }
-        return this;
-    }
-
-    public Order build() {
-        Order order = new Order();
-        order.setId(id);
-        order.setLineItems(lineItems);
-        return order;
-    }
-
-    public static OrderBuilder anOrder() {
-        return new OrderBuilder();
-    }
-}
-
-class OrderLineItemBuilder {
-    private Long id;
-    private Long quantity;
-    private Product product;
-
-    public OrderLineItemBuilder id(Long id) {
-        this.id = id;
-        return this;
-    }
-
-    public OrderLineItemBuilder quantity(Long quantity) {
-        this.quantity = quantity;
-        return this;
-    }
-
-    public OrderLineItemBuilder product(ProductBuilder productBuilder) {
-        this.product = productBuilder.build();
-        return this;
-    }
-
-    public OrderLineItem build() {
-        OrderLineItem lineItem = new OrderLineItem();
-        lineItem.setId(id);
-        lineItem.setQuantity(quantity);
-        lineItem.setProduct(product);
-        return lineItem;
-    }
-
-    public static OrderLineItemBuilder anOrderLineItem() {
-        return new OrderLineItemBuilder();
-    }
-}
-
-class ProductBuilder {
-    private Long id;
-    private String name;
-    private String description;
-    private BigDecimal price;
-
-
-    public ProductBuilder name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    public ProductBuilder price(String price) {
-        this.price = new BigDecimal(price);
-        return this;
-    }
-
-    public Product build() {
-        Product product = new Product();
-        product.setId(id);
-        product.setName(name);
-        product.setDescription(description);
-        product.setPrice(price);
-        return product;
-    }
-
-    public static ProductBuilder aProduct() {
-        return new ProductBuilder();
     }
 }

--- a/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
@@ -10,26 +10,28 @@ import static com.ktown4u.utils.ProductBuilder.aProduct;
 
 class YamlWriterTest {
 
-    private final Order order = anOrder()
-            .orderLineItems(
-                    anOrderLineItem()
-                            .quantity(2L)
-                            .product(
-                                    aProduct()
-                                            .name("Kenya AA Drip Coffee")
-                                            .description("Bright, citrusy, with a hint of cocoa and a smooth finish.")
-                                            .price("8000")
-                            ),
-                    anOrderLineItem()
-                            .quantity(1L)
-                            .product(
-                                    aProduct()
-                                            .name("Americano")
-                                            .description("2-shot original blend Americano.")
-                                            .price("5000")
-                            )
-            )
-            .build();
+    private final Order order =
+
+            anOrder()
+                    .orderLineItems(
+                            anOrderLineItem()
+                                    .quantity(2L)
+                                    .product(
+                                            aProduct()
+                                                    .name("Kenya AA Drip Coffee")
+                                                    .description("Bright, citrusy, with a hint of cocoa and a smooth finish.")
+                                                    .price("8000")
+                                    ),
+                            anOrderLineItem()
+                                    .quantity(1L)
+                                    .product(
+                                            aProduct()
+                                                    .name("Americano")
+                                                    .description("2-shot original blend Americano.")
+                                                    .price("5000")
+                                    )
+                    )
+                    .build();
 
     @Test
     @DisplayName("write - 모든 필드를 YAML 포멧 문자열로 반환.")

--- a/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
@@ -10,30 +10,32 @@ import static com.ktown4u.utils.ProductBuilder.aProduct;
 
 class YamlWriterTest {
 
+    private final Order order = anOrder()
+            .orderLineItems(
+                    anOrderLineItem()
+                            .quantity(2L)
+                            .product(
+                                    aProduct()
+                                            .name("Kenya AA Drip Coffee")
+                                            .description("Bright, citrusy, with a hint of cocoa and a smooth finish.")
+                                            .price("8000")
+                            ),
+                    anOrderLineItem()
+                            .quantity(1L)
+                            .product(
+                                    aProduct()
+                                            .name("Americano")
+                                            .description("2-shot original blend Americano.")
+                                            .price("5000")
+                            )
+            )
+            .build();
+
     @Test
     @DisplayName("write - 모든 필드를 YAML 포멧 문자열로 반환.")
     void write() {
-        final Order order = anOrder()
-                .orderLineItems(
-                        anOrderLineItem()
-                                .quantity(2L)
-                                .product(
-                                        aProduct()
-                                                .name("Kenya AA Drip Coffee")
-                                                .description("Bright, citrusy, with a hint of cocoa and a smooth finish.")
-                                                .price("8000")
-                                ),
-                        anOrderLineItem()
-                                .quantity(1L)
-                                .product(
-                                        aProduct()
-                                                .name("Americano")
-                                                .description("2-shot original blend Americano.")
-                                                .price("5000")
-                                )
-                )
-                .build();
+        final String result = YamlWriter.write(order);
 
-        Approvals.verify(YamlWriter.write(order));
+        Approvals.verify(result);
     }
 }

--- a/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
@@ -38,4 +38,13 @@ class YamlWriterTest {
 
         Approvals.verify(result);
     }
+
+    @Test
+    @DisplayName("writeWithExclusions - 원하는 필드를 제외하고 YAML 포멧 문자열로 반환.")
+    void writeWithExclusions() {
+        final String[] filedNamesToExclude = {"id", "description"};
+        final String result = YamlWriter.writeWithExclusions(order, filedNamesToExclude);
+
+        Approvals.verify(result);
+    }
 }

--- a/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.java
@@ -1,0 +1,39 @@
+package com.ktown4u.utils;
+
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.ktown4u.utils.OrderBuilder.anOrder;
+import static com.ktown4u.utils.OrderLineItemBuilder.anOrderLineItem;
+import static com.ktown4u.utils.ProductBuilder.aProduct;
+
+class YamlWriterTest {
+
+    @Test
+    @DisplayName("write - 모든 필드를 YAML 포멧 문자열로 반환.")
+    void write() {
+        final Order order = anOrder()
+                .orderLineItems(
+                        anOrderLineItem()
+                                .quantity(2L)
+                                .product(
+                                        aProduct()
+                                                .name("Kenya AA Drip Coffee")
+                                                .description("Bright, citrusy, with a hint of cocoa and a smooth finish.")
+                                                .price("8000")
+                                ),
+                        anOrderLineItem()
+                                .quantity(1L)
+                                .product(
+                                        aProduct()
+                                                .name("Americano")
+                                                .description("2-shot original blend Americano.")
+                                                .price("5000")
+                                )
+                )
+                .build();
+
+        Approvals.verify(YamlWriter.write(order));
+    }
+}

--- a/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.write.approved.txt
+++ b/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.write.approved.txt
@@ -1,0 +1,17 @@
+---
+id: null
+lineItems:
+- id: null
+  quantity: 2
+  product:
+    id: null
+    name: "Kenya AA Drip Coffee"
+    description: "Bright, citrusy, with a hint of cocoa and a smooth finish."
+    price: 8000
+- id: null
+  quantity: 1
+  product:
+    id: null
+    name: "Americano"
+    description: "2-shot original blend Americano."
+    price: 5000

--- a/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.writeWithExclusions.approved.txt
+++ b/lib/src/test/java/com/ktown4u/utils/YamlWriterTest.writeWithExclusions.approved.txt
@@ -1,0 +1,10 @@
+---
+lineItems:
+- quantity: 2
+  product:
+    name: "Kenya AA Drip Coffee"
+    price: 8000
+- quantity: 1
+  product:
+    name: "Americano"
+    price: 5000


### PR DESCRIPTION
## Description
`com.ktown4u.utils.PrettyJsonPrinter`를 프로젝트에서 사용해보니 다음과 같은 문제가 발견 됨:
- JPA persistence entity를 도메인 모델로 사용할 때, `mappedBy`를 사용해서 양방향 매핑을 하면 무한재귀에 빠짐.
- 먼저 직렬화하고 결과 문자열을 필터링하는 방식을 사용하면 위 문제를 회피할 수 없음. 따라서 jackson 필터링을 사용해서 특정 필드에 아예 접근하지 않도록 함.

## Exclude filter 적용 before & after

<img width="1463" alt="Screenshot 2024-02-10 at 4 12 25 PM" src="https://github.com/HMInternational/ktown4u-utils/assets/5006605/b6f4e861-4ef8-4043-93dd-d3a6c8685dbe">


## YAML 채택에 대해
- JSON에 비해 YAML이 더 간결하고 가독성이 높음.
- approval test에 더 이상적이라고 생각해서 채택함.

## YamlWriter 라는 이름에 대해
- 기존과 같이 printer라는 이름을 쓰려고 했으나, "print"는 표준출력 등을 통해 출력한다는 느낌이 강해서 "writer"라고 명명함.

## TODOs
- 원하는 필드만 포함해서 직렬화하기.
- "lineItems.id" 처럼 nested 한 객체의 필터링 다루기. (아쉽게도 이건 jackson 기능만으로는 좀 까다로운 것 같음)
