### PR TITLE
Feature/ 원하는 필드만 포함하는 printWithInclusions method 추가

### DIFF
--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -46,6 +46,10 @@ public enum YamlPrinter {
         }
     }
 
+    public static String printWithInclusions(final Object object, final String... fieldNamesToInclude) {
+        throw new UnsupportedOperationException("Unsupported printWithInclusions");
+    }
+
     @JsonFilter("PropertyFilter")
     private static class PropertyFilterMixIn {}
 }

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import java.util.Arrays;
+
 public enum YamlPrinter {
     ;
     private static final ObjectMapper mapper;
@@ -38,8 +40,14 @@ public enum YamlPrinter {
         return writeValueAsString(writer, object);
     }
 
-    public static String printWithInclusions(final Object object, final String... fieldNamesToInclude) {
-        throw new UnsupportedOperationException("Unsupported printWithInclusions");
+    public static String printWithInclusions(final Object object, final String... fieldPathToInclude) {
+        final String[] array = Arrays.stream(fieldPathToInclude)
+                .flatMap(s -> Arrays.stream(s.split("\\.")))
+                .toArray(String[]::new);
+        final SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.filterOutAllExcept(array);
+        final FilterProvider filterProvider = new SimpleFilterProvider().addFilter("PropertyFilter", filter);
+        final ObjectWriter writer = mapper.writer(filterProvider);
+        return writeValueAsString(writer, object);
     }
 
     private static String writeValueAsString(final ObjectWriter writer, final Object object) {

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -38,16 +38,16 @@ public enum YamlPrinter {
         return writeValueAsString(writer, object);
     }
 
+    public static String printWithInclusions(final Object object, final String... fieldNamesToInclude) {
+        throw new UnsupportedOperationException("Unsupported printWithInclusions");
+    }
+
     private static String writeValueAsString(final ObjectWriter writer, final Object object) {
         try {
             return writer.writeValueAsString(object);
         } catch (final JsonProcessingException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static String printWithInclusions(final Object object, final String... fieldNamesToInclude) {
-        throw new UnsupportedOperationException("Unsupported printWithInclusions");
     }
 
     @JsonFilter("PropertyFilter")

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -41,13 +41,16 @@ public enum YamlPrinter {
     }
 
     public static String printWithInclusions(final Object object, final String... fieldPathToInclude) {
-        final String[] array = Arrays.stream(fieldPathToInclude)
-                .flatMap(s -> Arrays.stream(s.split("\\.")))
-                .toArray(String[]::new);
-        final SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.filterOutAllExcept(array);
+        final SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.filterOutAllExcept(splitAndFlatten(fieldPathToInclude));
         final FilterProvider filterProvider = new SimpleFilterProvider().addFilter("PropertyFilter", filter);
         final ObjectWriter writer = mapper.writer(filterProvider);
         return writeValueAsString(writer, object);
+    }
+
+    private static String[] splitAndFlatten(final String[] fieldNamesToInclude) {
+        return Arrays.stream(fieldNamesToInclude)
+                .flatMap(s -> Arrays.stream(s.split("\\.")))
+                .toArray(String[]::new);
     }
 
     private static String writeValueAsString(final ObjectWriter writer, final Object object) {

--- a/lib/src/test/java/com/ktown4u/utils/YamlPrinterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlPrinterTest.java
@@ -52,8 +52,8 @@ class YamlPrinterTest {
     @Test
     @DisplayName("printWithInclusions - 원하는 필드만 포함하고 YAML 포멧 문자열로 반환.")
     void printWithInclusions() {
-        final String[] filedNamesToInclude = {"quantity", "description"};
-        final String result = YamlPrinter.printWithInclusions(order, filedNamesToInclude);
+        final String[] filedPathToInclude = {"lineItems.product.description", "lineItems.product.price"};
+        final String result = YamlPrinter.printWithInclusions(order, filedPathToInclude);
 
         Approvals.verify(result);
     }

--- a/lib/src/test/java/com/ktown4u/utils/YamlPrinterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlPrinterTest.java
@@ -48,4 +48,13 @@ class YamlPrinterTest {
 
         Approvals.verify(result);
     }
+
+    @Test
+    @DisplayName("printWithInclusions - 원하는 필드만 포함하고 YAML 포멧 문자열로 반환.")
+    void printWithInclusions() {
+        final String[] filedNamesToInclude = {"quantity", "description"};
+        final String result = YamlPrinter.printWithInclusions(order, filedNamesToInclude);
+
+        Approvals.verify(result);
+    }
 }


### PR DESCRIPTION
### 사용 방법
출력하고 싶은 필드의 객체 path 를 명시합니다.

``` java
final String[] filedPathToInclude = {"lineItems.product.description", "lineItems.product.price"};
final String result = YamlPrinter.printWithInclusions(order, filedPathToInclude);
```

```
---
lineItems:
- product:
    description: "Bright, citrusy, with a hint of cocoa and a smooth finish."
    price: 8000
- product:
    description: "2-shot original blend Americano."
    price: 5000
```

### 객체 depth가 있다면 원하지 않는 필드도 포함되는 버그
예컨대
organization.team.user.id 를 한다면,
organization.id 와 team.id 도 나오게 됩니다

### 디버그 찍으면서 알게된 것
- 예상은 했지만, 내부에서 reflection 사용해서 private 필드에 접근합니다
- ObjectMapper filter 를 쓰기에는 필터링 표현에 한계가 있습니다
  - 기존에 기원님이 만들어두신 printWithExclusions 도 동일
 
### Next
- 다음과 같이 직접 reflection 활용해서 구현한다면 재미있을 것 같습니다
  - depth를 구분한다
    - 객체가 무한하게 호출 되는 것을 막는다
    - 원하는 depth 의 필드만 추출한다
  - hibernate 영속 / 비영속 상태에서 모두 동작하도록 구현한다
    - try 로 exception 먹어버리고 무시하기

```
// String[] input = ["lineItems.product.description", "lineItems.quantity"]

//String[] 에서 . 으로 구분된 depth 를 추출해서, 배열로 저장한다

public String printWithInclusions(Object object, String... fieldPathToInclude) {
  List<?> extracted = extract(input);
  retrun findAndPrintFieldLoop(extracted)
}

private String findAndPrintFieldLoop(List<?> extracted) {
  loop {
    if not field matched:
      continue;
    try {
      if(hasDepth()) { // 여기에서 Hibernate 영속성 exception이 나는 것을 try로 먹어버리기
        printObject()
        findFieldLoop() // 재귀
      } else {
        printField()
      }
    }
  } // end of loop
  return accumulatedString;
}
```