### PR TITLE
Indented line formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ name value
 - 이럴 경우 이를 무력화(neutralize)하는 기능이 필요함
 
 ```java
+
 @Test
 void neutralizeLocalDateTime() {
     String string = "GoodsFamily{id=1, name='name', createdBy=1, updatedBy=null, createdAt=2021-08-01T00:00:00.000000, updatedAt=null, goodsFamily2Goods=[]}";
@@ -217,5 +218,42 @@ void neutralizeLocalDateTime() {
     assertThat(result).contains(Neutralizer.LOCAL_DATE_TIME_REPLACEMENT);
 }
 ```
-- 위와 같이 LocalDateTime을 toString()으로 변환한 값("2021-08-01T00:00:00.000000")을 `Neutralizer.LOCAL_DATE_TIME_REPLACEMENT`로 변환하는 기능을 제공한다.
+
+- 위와 같이 LocalDateTime을 toString()으로 변환한 값("2021-08-01T00:00:00.000000")을 `Neutralizer.LOCAL_DATE_TIME_REPLACEMENT`로 변환하는
+  기능을 제공한다.
 - 향후 LocalDateTime뿐만 아니라 다른 타입에 대해서도 제공할 예정
+
+## LineFormatter with depth(v1.5.0)
+
+- depth를 인자를 전달하면 depth만큼의 indentation 공백을 추가한 문자열을 반환한다
+
+```java
+@Test
+void multiple_lines_with_depth() {
+  LineFormatter lineFormatter = new LineFormatter(80);
+  List<IndentiedLine> lines = List.of(
+          new IndentiedLine(1, "key1", "value1"),
+          new IndentiedLine(1, "key2", "value2"),
+          new IndentiedLine(2, "key11", "value1"),
+          new IndentiedLine(2, "key12", "value2")
+  );
+  String formattedLine = lineFormatter.formatLineWithWhitespaces("key", null);
+  for (IndentiedLine line : lines) {
+    formattedLine += lineFormatter.formatLineWithWhitespaces(line.depth, line.name, line.value);
+  }
+  Approvals.verify(formattedLine);
+}
+
+record IndentiedLine(int depth, String name, String value) {
+}
+```
+
+- 이와 같이 호출하면 아래와 같은 결과를 얻을 수 있음
+
+```text
+key                                                                         null
+    key1                                                                  value1
+    key2                                                                  value2
+        key11                                                             value1
+        key12                                                             value2
+```

--- a/lib/src/main/java/com/ktown4u/utils/LineFormatter.java
+++ b/lib/src/main/java/com/ktown4u/utils/LineFormatter.java
@@ -9,10 +9,17 @@ public class LineFormatter {
     }
 
     public String formatLineWithWhitespaces(final String name, final Object value) {
-        final int length = null == value ? "null".length() : value.toString().length();
-        final int whitespaceSize = this.columns - name.length() - length;
+        final int whitespaceSize = this.columns - keyLength(name) - valueLength(value);
         return String.format("%s%s%s\n", name,
                 " ".repeat(Math.max(0, whitespaceSize)),
                 value);
+    }
+
+    private int keyLength(String name) {
+        return name.length();
+    }
+
+    private int valueLength(Object value) {
+        return null == value ? "null".length() : value.toString().length();
     }
 }

--- a/lib/src/main/java/com/ktown4u/utils/LineFormatter.java
+++ b/lib/src/main/java/com/ktown4u/utils/LineFormatter.java
@@ -9,8 +9,10 @@ public class LineFormatter {
     }
 
     public String formatLineWithWhitespaces(final String name, final Object value) {
-        final int length = null == value ? 4 : value.toString().length();
+        final int length = null == value ? "null".length() : value.toString().length();
         final int whitespaceSize = this.columns - name.length() - length;
-        return String.format("%s%s%s\n", name, " ".repeat(Math.max(0, whitespaceSize)), value);
+        return String.format("%s%s%s\n", name,
+                " ".repeat(Math.max(0, whitespaceSize)),
+                value);
     }
 }

--- a/lib/src/main/java/com/ktown4u/utils/LineFormatter.java
+++ b/lib/src/main/java/com/ktown4u/utils/LineFormatter.java
@@ -22,4 +22,9 @@ public class LineFormatter {
     private int valueLength(Object value) {
         return null == value ? "null".length() : value.toString().length();
     }
+
+    public String formatLineWithWhitespaces(int depth, String name, String value) {
+        String indentedName = " ".repeat(depth * 4) + name;
+        return formatLineWithWhitespaces(indentedName, value);
+    }
 }

--- a/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.java
@@ -1,0 +1,15 @@
+package com.ktown4u.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LineFormatterTest {
+    @Test
+    void line_with_no_depth() {
+        LineFormatter lineFormatter = new LineFormatter(80);
+        String formattedLine = lineFormatter.formatLineWithWhitespaces("name", "value");
+        String expected = "name                                                                       value\n";
+        assertThat(formattedLine).isEqualTo(expected);
+    }
+}

--- a/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.java
@@ -12,4 +12,12 @@ class LineFormatterTest {
         String expected = "name                                                                       value\n";
         assertThat(formattedLine).isEqualTo(expected);
     }
+
+    @Test
+    void line_with_depth() {
+        LineFormatter lineFormatter = new LineFormatter(80);
+        String formattedLine = lineFormatter.formatLineWithWhitespaces(1, "name", "value");
+        String expected = "    name                                                                   value\n";
+        assertThat(formattedLine).isEqualTo(expected);
+    }
 }

--- a/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.java
@@ -1,6 +1,9 @@
 package com.ktown4u.utils;
 
+import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,5 +22,24 @@ class LineFormatterTest {
         String formattedLine = lineFormatter.formatLineWithWhitespaces(1, "name", "value");
         String expected = "    name                                                                   value\n";
         assertThat(formattedLine).isEqualTo(expected);
+    }
+
+    @Test
+    void multiple_lines_with_depth() {
+        LineFormatter lineFormatter = new LineFormatter(80);
+        List<IndentiedLine> lines = List.of(
+                new IndentiedLine(1, "key1", "value1"),
+                new IndentiedLine(1, "key2", "value2"),
+                new IndentiedLine(2, "key11", "value1"),
+                new IndentiedLine(2, "key12", "value2")
+        );
+        String formattedLine = lineFormatter.formatLineWithWhitespaces("key", null);
+        for (IndentiedLine line : lines) {
+            formattedLine += lineFormatter.formatLineWithWhitespaces(line.depth, line.name, line.value);
+        }
+        Approvals.verify(formattedLine);
+    }
+
+    record IndentiedLine(int depth, String name, String value) {
     }
 }

--- a/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.multiple_lines_with_depth.approved.txt
+++ b/lib/src/test/java/com/ktown4u/utils/LineFormatterTest.multiple_lines_with_depth.approved.txt
@@ -1,0 +1,5 @@
+key                                                                         null
+    key1                                                                  value1
+    key2                                                                  value2
+        key11                                                             value1
+        key12                                                             value2


### PR DESCRIPTION
## LineFormatter with depth(v1.5.0)

- depth를 인자를 전달하면 depth만큼의 indentation 공백을 추가한 문자열을 반환한다

```java
@Test
void multiple_lines_with_depth() {
  LineFormatter lineFormatter = new LineFormatter(80);
  List<IndentiedLine> lines = List.of(
          new IndentiedLine(1, "key1", "value1"),
          new IndentiedLine(1, "key2", "value2"),
          new IndentiedLine(2, "key11", "value1"),
          new IndentiedLine(2, "key12", "value2")
  );
  String formattedLine = lineFormatter.formatLineWithWhitespaces("key", null);
  for (IndentiedLine line : lines) {
    formattedLine += lineFormatter.formatLineWithWhitespaces(line.depth, line.name, line.value);
  }
  Approvals.verify(formattedLine);
}

record IndentiedLine(int depth, String name, String value) {
}
```

- 이와 같이 호출하면 아래와 같은 결과를 얻을 수 있음

```text
key                                                                         null
    key1                                                                  value1
    key2                                                                  value2
        key11                                                             value1
        key12                                                             value2
```