### PR TITLE
Feature/im-584 객체 diff 를 비교하는 YmlPrinter MVP 구현

### DIFF
--- a/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
+++ b/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
@@ -1,11 +1,15 @@
 package com.ktown4u.utils;
 
-public class DiffStringBuilder {
+class DiffStringBuilder {
 
-    private final StringBuilder diffBuilder = new StringBuilder();
+    private final StringBuilder diffBuilder;
+
+    private DiffStringBuilder(StringBuilder diffBuilder) {
+        this.diffBuilder = diffBuilder;
+    }
 
     public static DiffStringBuilder init() {
-        return new DiffStringBuilder();
+        return new DiffStringBuilder(new StringBuilder());
     }
 
     public void appendConcur(final String fieldName, final Object value) {

--- a/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
+++ b/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
@@ -12,7 +12,7 @@ class DiffStringBuilder {
         return new DiffStringBuilder(new StringBuilder());
     }
 
-    public void appendConcur(final String fieldName, final Object value) {
+    public void appendEqual(final String fieldName, final Object value) {
         diffBuilder.append(fieldName)
                 .append(": ")
                 .append(value)

--- a/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
+++ b/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
@@ -1,0 +1,30 @@
+package com.ktown4u.utils;
+
+public class DiffStringBuilder {
+
+    private final StringBuilder diffBuilder = new StringBuilder();
+
+    public static DiffStringBuilder init() {
+        return new DiffStringBuilder();
+    }
+
+    public void appendConcur(final String fieldName, final Object value) {
+        diffBuilder.append(fieldName)
+                .append(": ")
+                .append(value)
+                .append("\n");
+    }
+
+    public void appendDiff(final String fieldName, final Object value1, final Object value2) {
+        diffBuilder.append(fieldName)
+                .append(": ")
+                .append(value1)
+                .append(" -> ")
+                .append(value2)
+                .append("\n");
+    }
+
+    public String toString() {
+        return diffBuilder.toString();
+    }
+}

--- a/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
+++ b/lib/src/main/java/com/ktown4u/utils/DiffStringBuilder.java
@@ -19,12 +19,12 @@ class DiffStringBuilder {
                 .append("\n");
     }
 
-    public void appendDiff(final String fieldName, final Object value1, final Object value2) {
+    public void appendDiff(final String fieldName, final Object beforeValue, final Object afterValue) {
         diffBuilder.append(fieldName)
                 .append(": ")
-                .append(value1)
+                .append(beforeValue)
                 .append(" -> ")
-                .append(value2)
+                .append(afterValue)
                 .append("\n");
     }
 

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Objects;
 
 public enum YamlPrinter {
     ;
@@ -60,18 +61,13 @@ public enum YamlPrinter {
                 final Object value1 = field.get(object1);
                 final Object value2 = field.get(object2);
 
-                if (value1 == null && value2 == null) {
+                if (Objects.equals(value1, value2)) {
                     diffBuilder.appendConcur(field.getName(), value1);
                     continue;
                 }
 
                 if (value1 == null || value2 == null) {
                     diffBuilder.appendDiff(field.getName(), value1, value2);
-                    continue;
-                }
-
-                if (value1.equals(value2)) {
-                    diffBuilder.appendConcur(field.getName(), value1);
                     continue;
                 }
 

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -49,20 +49,20 @@ public enum YamlPrinter {
         return writeValueAsString(writer, object);
     }
 
-    public static <T> String printDiff(final T object1, final T object2) {
+    public static <T> String printDiff(final T beforeObj, final T afterObj) {
         final DiffStringBuilder diffBuilder = DiffStringBuilder.init();
-        final Field[] fields = object1.getClass().getDeclaredFields();
+        final Field[] fields = beforeObj.getClass().getDeclaredFields();
 
         try {
             for (final Field field : fields) {
                 field.setAccessible(true);
-                final Object value1 = field.get(object1);
-                final Object value2 = field.get(object2);
+                final Object beforeValue = field.get(beforeObj);
+                final Object afterValue = field.get(afterObj);
 
-                if (Objects.equals(value1, value2)) {
-                    diffBuilder.appendConcur(field.getName(), value1);
+                if (Objects.equals(beforeValue, afterValue)) {
+                    diffBuilder.appendConcur(field.getName(), beforeValue);
                 } else {
-                    diffBuilder.appendDiff(field.getName(), value1, value2);
+                    diffBuilder.appendDiff(field.getName(), beforeValue, afterValue);
                 }
             }
         } catch (final IllegalAccessException e) {

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -60,7 +60,7 @@ public enum YamlPrinter {
                 final Object afterValue = field.get(afterObj);
 
                 if (Objects.equals(beforeValue, afterValue)) {
-                    diffBuilder.appendConcur(field.getName(), beforeValue);
+                    diffBuilder.appendEqual(field.getName(), beforeValue);
                 } else {
                     diffBuilder.appendDiff(field.getName(), beforeValue, afterValue);
                 }

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -66,11 +66,6 @@ public enum YamlPrinter {
                     continue;
                 }
 
-                if (value1 == null || value2 == null) {
-                    diffBuilder.appendDiff(field.getName(), value1, value2);
-                    continue;
-                }
-
                 diffBuilder.appendDiff(field.getName(), value1, value2);
             }
         } catch (final IllegalAccessException e) {

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -51,7 +51,7 @@ public enum YamlPrinter {
     public static <T> String printDiff(final T object1, final T object2) {
         final Class<?> reflected = object1.getClass();
 
-        final StringBuilder diffBuilder = new StringBuilder();
+        final DiffStringBuilder diffBuilder = DiffStringBuilder.init();
         final Field[] fields = reflected.getDeclaredFields();
 
         try {
@@ -61,37 +61,21 @@ public enum YamlPrinter {
                 final Object value2 = field.get(object2);
 
                 if (value1 == null && value2 == null) {
-                    diffBuilder.append(field.getName())
-                            .append(": ")
-                            .append(value1)
-                            .append("\n");
+                    diffBuilder.appendConcur(field.getName(), value1);
                     continue;
                 }
 
                 if (value1 == null || value2 == null) {
-                    diffBuilder.append(field.getName())
-                            .append(": ")
-                            .append(value1)
-                            .append(" -> ")
-                            .append(value2)
-                            .append("\n");
+                    diffBuilder.appendDiff(field.getName(), value1, value2);
                     continue;
                 }
 
                 if (value1.equals(value2)) {
-                    diffBuilder.append(field.getName())
-                            .append(": ")
-                            .append(value1)
-                            .append("\n");
+                    diffBuilder.appendConcur(field.getName(), value1);
                     continue;
                 }
 
-                diffBuilder.append(field.getName())
-                        .append(": ")
-                        .append(value1)
-                        .append(" -> ")
-                        .append(value2)
-                        .append("\n");
+                diffBuilder.appendDiff(field.getName(), value1, value2);
             }
         } catch (final IllegalAccessException e) {
             throw new RuntimeException(e);

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -68,7 +68,7 @@ public enum YamlPrinter {
                 }
             }
         } catch (final IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to access field", e);
         }
 
         return diffBuilder.toString();

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -62,7 +62,9 @@ public enum YamlPrinter {
 
                 if (value1 == null && value2 == null) {
                     diffBuilder.append(field.getName())
-                            .append(": null\n");
+                            .append(": ")
+                            .append(value1)
+                            .append("\n");
                     continue;
                 }
 

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -50,10 +50,8 @@ public enum YamlPrinter {
     }
 
     public static <T> String printDiff(final T object1, final T object2) {
-        final Class<?> reflected = object1.getClass();
-
         final DiffStringBuilder diffBuilder = DiffStringBuilder.init();
-        final Field[] fields = reflected.getDeclaredFields();
+        final Field[] fields = object1.getClass().getDeclaredFields();
 
         try {
             for (final Field field : fields) {

--- a/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/YamlPrinter.java
@@ -63,10 +63,9 @@ public enum YamlPrinter {
 
                 if (Objects.equals(value1, value2)) {
                     diffBuilder.appendConcur(field.getName(), value1);
-                    continue;
+                } else {
+                    diffBuilder.appendDiff(field.getName(), value1, value2);
                 }
-
-                diffBuilder.appendDiff(field.getName(), value1, value2);
             }
         } catch (final IllegalAccessException e) {
             throw new RuntimeException(e);

--- a/lib/src/test/java/com/ktown4u/utils/Order.java
+++ b/lib/src/test/java/com/ktown4u/utils/Order.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 class Order {
     private Long id;
+    private Long customerId;
     private List<OrderLineItem> lineItems;
 
     public Long getId() {
@@ -13,6 +14,10 @@ class Order {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public void setCustomerId(Long customerId) {
+        this.customerId = customerId;
     }
 
     public List<OrderLineItem> getLineItems() {

--- a/lib/src/test/java/com/ktown4u/utils/OrderBuilder.java
+++ b/lib/src/test/java/com/ktown4u/utils/OrderBuilder.java
@@ -6,10 +6,16 @@ import java.util.List;
 
 class OrderBuilder {
     private Long id;
+    private Long customerId;
     private List<OrderLineItem> lineItems = new ArrayList<>();
 
     public OrderBuilder id(Long id) {
         this.id = id;
+        return this;
+    }
+
+    public OrderBuilder customerId(Long customerId) {
+        this.customerId = customerId;
         return this;
     }
 
@@ -23,6 +29,7 @@ class OrderBuilder {
     public Order build() {
         Order order = new Order();
         order.setId(id);
+        order.setCustomerId(customerId);
         order.setLineItems(lineItems);
         return order;
     }

--- a/lib/src/test/java/com/ktown4u/utils/PrettyJsonPrinterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/PrettyJsonPrinterTest.java
@@ -33,6 +33,7 @@ class PrettyJsonPrinterTest {
 
         Approvals.verify(PrettyJsonPrinter.prettyPrint(order).stream()
                 .filter(outLinesIncluding("id"))
+                .filter(outLinesIncluding("customerId"))
                 .filter(outLinesIncluding("description"))
                 .collect(joining("\n"))
         );

--- a/lib/src/test/java/com/ktown4u/utils/YamlPrinterPrintDiffTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlPrinterPrintDiffTest.java
@@ -1,0 +1,39 @@
+package com.ktown4u.utils;
+
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.ktown4u.utils.OrderBuilder.anOrder;
+
+class YamlPrinterPrintDiffTest {
+
+    @Test
+    @DisplayName("printDiff - 두 객체의 차이를 YAML 포멧 문자열로 반환.")
+    void printDiff() {
+        final Long customer = 1L;
+        final Order order1 = anOrder().id(1L).customerId(customer).build();
+        final Order order2 = anOrder().id(2L).customerId(customer).build();
+
+        final String result = YamlPrinter.printDiff(order1, order2);
+
+        Approvals.verify(result);
+    }
+
+    @Test
+    @DisplayName("printDiff - null 도 비교가 가능하다.")
+    void printDiffCanCompareNull() {
+        final Order order1 = anOrder().id(1L).customerId(null).build();
+        final Order order2 = anOrder().id(2L).customerId(null).build();
+        final String result1 = YamlPrinter.printDiff(order1, order2);
+
+        final Order order3 = anOrder().id(1L).customerId(1L).build();
+        final Order order4 = anOrder().id(2L).customerId(null).build();
+        final String result2 = YamlPrinter.printDiff(order3, order4);
+
+        Approvals.verify(result1 + result2);
+    }
+
+    // todo: depth 2 이상의 객체 비교 테스트 추가
+
+}

--- a/lib/src/test/java/com/ktown4u/utils/YamlPrinterPrintDiffTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlPrinterPrintDiffTest.java
@@ -21,17 +21,25 @@ class YamlPrinterPrintDiffTest {
     }
 
     @Test
-    @DisplayName("printDiff - null 도 비교가 가능하다.")
+    @DisplayName("printDiff - null 과의 비교가 가능하다.")
     void printDiffCanCompareNull() {
+        final Order order1 = anOrder().id(1L).customerId(1L).build();
+        final Order order2 = anOrder().id(2L).customerId(null).build();
+
+        final String result = YamlPrinter.printDiff(order1, order2);
+
+        Approvals.verify(result);
+    }
+
+    @Test
+    @DisplayName("printDiff - null 끼리도 비교가 가능하다.")
+    void printDiffCanCompareBothNull() {
         final Order order1 = anOrder().id(1L).customerId(null).build();
         final Order order2 = anOrder().id(2L).customerId(null).build();
+
         final String result1 = YamlPrinter.printDiff(order1, order2);
 
-        final Order order3 = anOrder().id(1L).customerId(1L).build();
-        final Order order4 = anOrder().id(2L).customerId(null).build();
-        final String result2 = YamlPrinter.printDiff(order3, order4);
-
-        Approvals.verify(result1 + result2);
+        Approvals.verify(result1);
     }
 
     // todo: depth 2 이상의 객체 비교 테스트 추가

--- a/lib/src/test/java/com/ktown4u/utils/YamlPrinterTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/YamlPrinterTest.java
@@ -12,6 +12,7 @@ class YamlPrinterTest {
 
     private final Order order =
             anOrder()
+                    .customerId(1L)
                     .orderLineItems(
                             anOrderLineItem()
                                     .quantity(2L)


### PR DESCRIPTION
객체 diff 를 출력하는 기능을 MVP 버전으로 만들어봤습니다.
before object 와 after object 를 비교하기 위한 목적입니다 ㅎㅎ..

### 예시
```yml
id: 1 -> 2 // 변경된 값
customerId: 1 // 변경되지 않은 값
lineItems: []
```

### Next
이번주에 심심하면 추가 구현을 해보려고 합니다.
- 객체 depth 를 표현
- 원하는 필드 지정
- 원하지 않는 필드 지정
- 필드 지정의 depth 구분
