### PR TITLE
Markdown 문자열 비교를 객체 비교로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class SteamUtilsTest {
         assertThat(users).containsExactly(new User("msbaek", 1l), new User("msbaek2", 2l));
     }
 
-    private Collection<User> listUsersBy(Collection<Long> ids) {
+    private Collection<User> listUsersBy(final Collection<Long> ids) {
         return sourceCollection.stream()
                 .filter(user -> ids.contains(user.id()))
                 .toList();
@@ -211,9 +211,9 @@ name value
 
 @Test
 void neutralizeLocalDateTime() {
-    String string = "GoodsFamily{id=1, name='name', createdBy=1, updatedBy=null, createdAt=2021-08-01T00:00:00.000000, updatedAt=null, goodsFamily2Goods=[]}";
+    final String string = "GoodsFamily{id=1, name='name', createdBy=1, updatedBy=null, createdAt=2021-08-01T00:00:00.000000, updatedAt=null, goodsFamily2Goods=[]}";
 
-    String result = Neutralizer.localDateTime(string);
+  final String result = Neutralizer.localDateTime(string);
 
     assertThat(result).contains(Neutralizer.LOCAL_DATE_TIME_REPLACEMENT);
 }
@@ -230,8 +230,8 @@ void neutralizeLocalDateTime() {
 ```java
 @Test
 void multiple_lines_with_depth() {
-  LineFormatter lineFormatter = new LineFormatter(80);
-  List<IndentiedLine> lines = List.of(
+  final LineFormatter lineFormatter = new LineFormatter(80);
+  final List<IndentiedLine> lines = List.of(
           new IndentiedLine(1, "key1", "value1"),
           new IndentiedLine(1, "key2", "value2"),
           new IndentiedLine(2, "key11", "value1"),
@@ -300,14 +300,15 @@ approved.text
 
 ```java
     @Test
-    @DisplayName("두 문자열을 비교한다")
+@DisplayName("두 객체를 비교한다")
     void git_diff() {
-        final String before = before();
-        final String after = after();
+  final Order before = beforeOrder();
+  final Order after = afterOrder();
 
         Approvals.verify(
-                Markdown.title("두 문자열을 비교한다.")
-                        .description("두 문자열을 비교하여 markdown diff 포맷으로 차이를 확인한다.")
+                Markdown.title("두 객체를 비교한다.")
+                        .description("두 객체를 비교하여 markdown diff 포맷으로 차이를 확인한다.")
+                        .excluding("id", "description")
                         .diff(before, after));
-    }
+}
 ```

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "com.ktown4u"
             artifactId = "utils"
-            version = "1.7.0"
+            version = "1.7.2"
 
             from(components["java"])
         }

--- a/lib/src/main/java/com/ktown4u/utils/Markdown.java
+++ b/lib/src/main/java/com/ktown4u/utils/Markdown.java
@@ -11,6 +11,7 @@ class Markdown {
     private final String title;
     private final DiffRowGenerator generator;
     private String description = "";
+    private String[] fieldsToIgnore = {};
 
     private Markdown(final String title) {
         this.title = title;
@@ -26,9 +27,18 @@ class Markdown {
         return this;
     }
 
-    public Verifiable diff(final String before, final String after) {
-        final List<DiffRow> diffRows = getDiffRows(before, after);
+    public Markdown excluding(final String... fields) {
+        fieldsToIgnore = fields;
+        return this;
+    }
+
+    public Verifiable diff(final Object before, final Object after) {
+        final List<DiffRow> diffRows = getDiffRows(format(before), format(after));
         return new MarkdownParagraph(title, description, reduceToString(diffRows));
+    }
+
+    private String format(final Object before) {
+        return YamlPrinter.printWithExclusions(before, fieldsToIgnore).replaceAll("(?m)^- ", "* ");
     }
 
     private DiffRowGenerator buildGenerator() {

--- a/lib/src/test/java/com/ktown4u/utils/DiffTest.git_diff.approved.md
+++ b/lib/src/test/java/com/ktown4u/utils/DiffTest.git_diff.approved.md
@@ -1,39 +1,19 @@
-# 두 문자열을 비교한다.
-
-두 문자열을 비교하여 markdown diff 포맷으로 차이를 확인한다.
+# 두 객체를 비교한다.
+두 객체를 비교하여 markdown diff 포맷으로 차이를 확인한다.
 ```diff
-- totalPrice: 0
-+ totalPrice: 100
-- totalDiscountPrice: 0
-+ totalDiscountPrice: 10
-- finalPrice: 0
-+ finalPrice: 90
-mileageToBeEarned: 0
-- totalQty: 0
-+ totalQty: 2
-currency: "USD"
-tube:
-  name: ""
-  price: 0
-  qty: 0
-  active: false
-- items: []
-+ items:
-+ - productId:
-+     shopNo: 164
-+     productNo: 1
-+     bundleNo: 2
-+     fanClubProductNo: 3
-+     eventNo: 4
-+   qty: 2
-+   name: "name"
-+   image: "image"
-+   retailPrice: 100
-+   sellPrice: 90
-+   artist: "artist"
-+   brand: "brand"
-+   saleStatusCode: "ON_SALE"
-+   isAdultOnly: true
-+   additionalItems: []
+---
+lineItems:
+- * quantity: 2
++ * quantity: 3
+  product:
+-     name: "coffee"
++     name: "latte"
+-     price: 1000
++     price: 3000
+* quantity: 1
+  product:
+-     name: "Learning Spring Boot 2.0"
++     name: "Learning Spring Boot 3.0"
+    price: 30000
 
 ```

--- a/lib/src/test/java/com/ktown4u/utils/DiffTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/DiffTest.java
@@ -4,6 +4,10 @@ import org.approvaltests.Approvals;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.ktown4u.utils.OrderBuilder.anOrder;
+import static com.ktown4u.utils.OrderLineItemBuilder.anOrderLineItem;
+import static com.ktown4u.utils.ProductBuilder.aProduct;
+
 public class DiffTest {
     @Test
     @DisplayName("두 문자열을 비교한다")
@@ -15,15 +19,58 @@ public class DiffTest {
     }
 
     @Test
-    @DisplayName("두 문자열을 비교한다")
+    @DisplayName("두 객체를 비교한다")
     void git_diff() {
-        final String before = before();
-        final String after = after();
+        final Order before = beforeOrder();
+        final Order after = afterOrder();
 
         Approvals.verify(
                 Markdown.title("두 문자열을 비교한다.")
                         .description("두 문자열을 비교하여 markdown diff 포맷으로 차이를 확인한다.")
+                        .excluding("id", "description")
                         .diff(before, after));
+    }
+
+    private Order beforeOrder() {
+        return anOrder()
+                .orderLineItems(
+                        anOrderLineItem()
+                                .quantity(2L)
+                                .product(
+                                        aProduct()
+                                                .name("coffee")
+                                                .price("1000")
+                                ),
+                        anOrderLineItem()
+                                .quantity(1L)
+                                .product(
+                                        aProduct()
+                                                .name("Learning Spring Boot 2.0")
+                                                .price("30000")
+                                )
+                )
+                .build();
+    }
+
+    private Order afterOrder() {
+        return anOrder()
+                .orderLineItems(
+                        anOrderLineItem()
+                                .quantity(3L)
+                                .product(
+                                        aProduct()
+                                                .name("latte")
+                                                .price("3000")
+                                ),
+                        anOrderLineItem()
+                                .quantity(1L)
+                                .product(
+                                        aProduct()
+                                                .name("Learning Spring Boot 3.0")
+                                                .price("30000")
+                                )
+                )
+                .build();
     }
 
     private String after() {

--- a/lib/src/test/java/com/ktown4u/utils/DiffTest.java
+++ b/lib/src/test/java/com/ktown4u/utils/DiffTest.java
@@ -25,8 +25,8 @@ public class DiffTest {
         final Order after = afterOrder();
 
         Approvals.verify(
-                Markdown.title("두 문자열을 비교한다.")
-                        .description("두 문자열을 비교하여 markdown diff 포맷으로 차이를 확인한다.")
+                Markdown.title("두 객체를 비교한다.")
+                        .description("두 객체를 비교하여 markdown diff 포맷으로 차이를 확인한다.")
                         .excluding("id", "description")
                         .diff(before, after));
     }


### PR DESCRIPTION
- 객체를 전달하면 문자열로 변환하여 차이를 비교하도록 수정
- 객체에서 출력하지 않을 필드를 선택할 수 있음