### PR TITLE
feat: Jackson 2.16.1에서 3.0.3으로 업그레이드

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ approved.text
 `++`: 추가된 라인  
 `--`: 삭제된 라인
 
+## Jackson 3 업그레이드(v1.8.0)
+
+- Spring Boot 4.0.1 호환을 위해 Jackson 2.16.1에서 3.0.3으로 업그레이드
+- 주요 변경사항:
+  - Group ID 변경: `com.fasterxml.jackson` → `tools.jackson`
+  - `ObjectMapper` → `JsonMapper`/`YAMLMapper` (immutable Builder 패턴)
+  - `jackson-datatype-jsr310` 의존성 제거 (jackson-databind에 내장)
+
 ## Diff in Markdown(v1.7.0)
 
 - 서로 다른 문자열을 전달하면 approval test를 통해 두 문자열의 차이를 볼 수 있는 .md 파일을 자동 생성한다.

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk8
+  - openjdk17

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -19,14 +19,12 @@ publishing {
     }
 }
 
-val jacksonVersion by extra { "2.16.1" }
+val jacksonVersion by extra { "3.0.3" }
 
 dependencies {
-    // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
+    implementation("tools.jackson.core:jackson-core:$jacksonVersion")
+    implementation("tools.jackson.core:jackson-databind:$jacksonVersion")
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
     implementation("com.approvaltests:approvaltests:22.3.3")
 
     // diff utils
@@ -41,17 +39,11 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
     withJavadocJar()
     withSourcesJar()
-}
-
-tasks.withType<JavaCompile> {
-    if (name.contains("Test")) {
-        sourceCompatibility = JavaVersion.VERSION_17.toString()
-        targetCompatibility = JavaVersion.VERSION_17.toString()
-    }
 }
 
 tasks.named<Test>("test") {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "com.ktown4u"
             artifactId = "utils"
-            version = "1.7.2"
+            version = "1.8.0"
 
             from(components["java"])
         }

--- a/lib/src/main/java/com/ktown4u/utils/PrettyJsonPrinter.java
+++ b/lib/src/main/java/com/ktown4u/utils/PrettyJsonPrinter.java
@@ -4,50 +4,35 @@
 package com.ktown4u.utils;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.SerializationFeature;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
 public class PrettyJsonPrinter {
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static ObjectMapper mapper;
+    private static final JsonMapper mapper;
 
     static {
-        mapper = new ObjectMapper();
-        final JavaTimeModule javaTimeModule = new JavaTimeModule();
-        javaTimeModule.addSerializer(LocalDate.class, new LocalDateSerializer(DATE_TIME_FORMATTER));
-        javaTimeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(DATE_TIME_FORMATTER));
-        javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DATE_TIME_FORMATTER));
-        javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(DATE_TIME_FORMATTER));
-
-        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE); // Disable auto-detection for all methods
-        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY); // Enable visibility for fields
-
-        mapper.registerModule(javaTimeModule);
+        mapper = JsonMapper.builder()
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                // Jackson 3에서 기본값이 true로 변경됨. Jackson 2와 동일한 필드 순서 유지를 위해 비활성화
+                .disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+                .changeDefaultVisibility(vc -> vc
+                        .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                        .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                        .withCreatorVisibility(JsonAutoDetect.Visibility.NONE)
+                        .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                        .withFieldVisibility(JsonAutoDetect.Visibility.ANY))
+                .build();
     }
 
     public static List<String> prettyPrint(Object object) {
-        try {
-            return Arrays.asList(
-                    mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object)
-                            .split("\n"));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        return Arrays.asList(
+                mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object)
+                        .split("\n"));
     }
 
     public static Predicate<String> outLinesIncluding(String fieldNameToExclude) {


### PR DESCRIPTION
## Summary

- Jackson 2.16.1에서 3.0.3으로 업그레이드
- Spring Boot 4에서 Jackson 기본 의존성이 3.x로 변경됨에 따른 호환성 확보

## Why

Spring Boot 4.0.1은 Jackson 3을 기본 JSON 라이브러리로 사용합니다. 
이 유틸리티 라이브러리가 Spring Boot 4 기반 프로젝트에서 사용될 때 
Jackson 버전 충돌 없이 동작하도록 업그레이드합니다.

## Changes

- Group ID 변경: `com.fasterxml.jackson` → `tools.jackson`
- `ObjectMapper` → `JsonMapper`/`YAMLMapper` (immutable Builder 패턴)
- `jackson-datatype-jsr310` 의존성 제거 (jackson-databind에 내장)
- `SimpleBeanPropertyFilter` 패키지 이동: `ser.impl` → `ser.std`
- `SORT_PROPERTIES_ALPHABETICALLY` 비활성화 (Jackson 2 호환 유지)
- Java 버전 1.8 → 17 (Jackson 3 요구사항)

## Test plan

- [x] 기존 테스트 케이스 모두 통과
- [x] `PrettyJsonPrinter` 동작 검증
- [x] `YamlPrinter` 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
