### PR TITLE
chore: Jackson/JUnit BOM 적용으로 의존성 버전 통합 관리

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -30,7 +30,8 @@ dependencies {
     implementation("io.github.java-diff-utils:java-diff-utils:4.12")
 
     // Use JUnit Jupiter for testing.
-    testImplementation(libs.junit.jupiter)
+    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.assertj:assertj-core:3.25.2")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,19 +12,18 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "com.ktown4u"
             artifactId = "utils"
-            version = "1.8.0"
+            version = "1.8.1"
 
             from(components["java"])
         }
     }
 }
 
-val jacksonVersion by extra { "3.0.3" }
-
 dependencies {
-    implementation("tools.jackson.core:jackson-core:$jacksonVersion")
-    implementation("tools.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
+    implementation(platform("tools.jackson:jackson-bom:3.0.3"))
+    implementation("tools.jackson.core:jackson-core")
+    implementation("tools.jackson.core:jackson-databind")
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.approvaltests:approvaltests:22.3.3")
 
     // diff utils


### PR DESCRIPTION
## Summary
- Jackson BOM 적용으로 jackson-core, jackson-databind, jackson-dataformat-yaml 버전 통합 관리
- JUnit BOM 적용으로 junit-jupiter, junit-platform-launcher 버전 통합 관리
- 버전 1.8.1로 업데이트

## Changes
- `platform("tools.jackson:jackson-bom:3.0.3")` 추가
- `platform("org.junit:junit-bom:5.10.0")` 추가
- 개별 의존성에서 버전 명시 제거

## Benefits
- 모듈 간 버전 불일치 방지
- 버전 업그레이드 시 단일 지점에서 관리 가능
